### PR TITLE
検索画面の在庫表示修正、カレンダー位置修正、カレンダー追従

### DIFF
--- a/src/gui/RentalFrame.java
+++ b/src/gui/RentalFrame.java
@@ -52,6 +52,8 @@ public class RentalFrame extends JFrame {
     // Field to hold ReserveCalendar instance
     private ReserveCalendar calendarDialog;
     
+    private boolean isInitializing = true; // 初期化中フラグを追加
+    
     public RentalFrame(String memberId, Costume costume) {
         this.currentMemberId = memberId;
         this.selectedCostume = costume;
@@ -63,6 +65,19 @@ public class RentalFrame extends JFrame {
         updateCostumeInfo();
         updatePriceCalculation();
         setupFrame();
+        
+        // 初期化完了
+        isInitializing = false;
+        
+        // --- ここから追加: 初期カレンダー表示 ---
+        // RentalFrameが完全に表示された後に、最初に選択されているサイズのカレンダーを表示
+        SwingUtilities.invokeLater(() -> {
+            String selectedSize = (String) sizeComboBox.getSelectedItem();
+            if (selectedSize != null) {
+                showInitialCalendar(selectedSize);
+            }
+        });
+        // --- ここまで追加 ---
     }
     
     private void initializeComponents() {
@@ -462,9 +477,28 @@ public class RentalFrame extends JFrame {
         return panel;
     }
     
+    // --- ここから追加 ---
+    /**
+     * 初期カレンダーを表示する
+     */
+    private void showInitialCalendar(String selectedSize) {
+        if (calendarDialog == null) {
+            calendarDialog = new ReserveCalendar(this, selectedCostume.getCostumeId(), selectedSize);
+            positionCalendarToRight();
+            calendarDialog.setSize(350, 350);
+            calendarDialog.setVisible(true);
+        }
+    }
+    // --- ここまで追加 ---
+    
     private void setupEventListeners() {
         // Size change event listener
         sizeComboBox.addActionListener(e -> {
+            // 初期化中はカレンダーを表示しない
+            if (isInitializing) {
+                return;
+            }
+            
             String selectedSize = (String) sizeComboBox.getSelectedItem();
             if (selectedSize == null) {
                 return;
@@ -476,18 +510,21 @@ public class RentalFrame extends JFrame {
             // Calendar display logic
             // If calendar is not created or not visible
             if (calendarDialog == null || !calendarDialog.isVisible()) {
-                calendarDialog = new ReserveCalendar(this, selectedCostume.getCostumeId(), selectedSize);
-                
-                // Position to the right of RentalFrame
-                Point location = this.getLocation();
-                calendarDialog.setLocation(location.x + this.getWidth(), location.y);
-                // Set smaller size
-                calendarDialog.setSize(350, 350); 
-                calendarDialog.setVisible(true);
+                // RentalFrameが完全に表示されてからカレンダーを表示
+                SwingUtilities.invokeLater(() -> {
+                    calendarDialog = new ReserveCalendar(this, selectedCostume.getCostumeId(), selectedSize);
+                    
+                    // RentalFrameの右側に正確に配置
+                    positionCalendarToRight();
+                    
+                    calendarDialog.setSize(350, 350); 
+                    calendarDialog.setVisible(true);
+                });
             } else {
                 // If already displayed, update with new information
                 calendarDialog.updateData(selectedCostume.getCostumeId(), selectedSize);
-                // Bring to front
+                // Bring to front and reposition
+                positionCalendarToRight();
                 calendarDialog.toFront();
             }
         });
@@ -521,6 +558,10 @@ public class RentalFrame extends JFrame {
         cancelButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
+                // カレンダーも閉じる
+                if (calendarDialog != null) {
+                    calendarDialog.dispose();
+                }
                 dispose();
             }
         });
@@ -731,6 +772,11 @@ public class RentalFrame extends JFrame {
                     "Rental Confirmed",
                     JOptionPane.INFORMATION_MESSAGE);
                 
+                // カレンダーも閉じる
+                if (calendarDialog != null) {
+                    calendarDialog.dispose();
+                }
+                
                 dispose(); // Close window
                 
             } else {
@@ -749,12 +795,59 @@ public class RentalFrame extends JFrame {
         }
     }
     
+    // --- ここから追加 ---
+    /**
+     * カレンダーをRentalFrameの右側に配置する
+     */
+    private void positionCalendarToRight() {
+        if (calendarDialog != null) {
+            // RentalFrameの現在の位置とサイズを取得
+            Point frameLocation = this.getLocationOnScreen();
+            int frameWidth = this.getWidth();
+            int frameHeight = this.getHeight();
+            
+            // カレンダーの位置を計算（右側に配置）
+            int calendarX = frameLocation.x + frameWidth + 10; // 10pxの余白
+            int calendarY = frameLocation.y;
+            
+            // 画面の境界をチェック
+            Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+            int calendarWidth = 350;
+            
+            // 画面右端を超える場合は左側に配置
+            if (calendarX + calendarWidth > screenSize.width) {
+                calendarX = frameLocation.x - calendarWidth - 10; // 左側に配置
+            }
+            
+            // 画面下端を超える場合は調整
+            if (calendarY + 350 > screenSize.height) {
+                calendarY = screenSize.height - 350 - 50; // 画面下端から50px上
+            }
+            
+            calendarDialog.setLocation(calendarX, calendarY);
+        }
+    }
+    // --- ここまで追加 ---
+    
     private void setupFrame() {
         setTitle("Costume Rental - " + selectedCostume.getCostumeName());
         setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         setSize(700, 700); // Increase height by 100px
         setLocationRelativeTo(null);
         setResizable(false);
+        
+        // --- ここから追加: ウィンドウが表示された後の処理 ---
+        // ウィンドウが表示された後にカレンダーの位置を再調整
+        addComponentListener(new java.awt.event.ComponentAdapter() {
+            @Override
+            public void componentMoved(java.awt.event.ComponentEvent e) {
+                // RentalFrameが移動したときにカレンダーも一緒に移動
+                if (calendarDialog != null && calendarDialog.isVisible()) {
+                    positionCalendarToRight();
+                }
+            }
+        });
+        // --- ここまで追加 ---
     }
     
     private String getTermsAndConditions() {


### PR DESCRIPTION
## 概要

- このプルリクで何をしたのか？
・コスチューム検索画面で在庫が常に最大になっていた問題を修正、リアルタイムの在庫が表示されるように
・レンタル画面を開くと在庫カレンダーがウィンドウの左側に表示されていた問題を修正。
・在庫カレンダーがレンタル画面に追従するように変更

## 動作確認

- スクリーンショットやテスト結果を記載・添付してください。

![無題の動画 ‐ Clipchampで作成](https://github.com/user-attachments/assets/9f689fc6-e3f8-4e7c-bb46-5b18e1d6688b)

![image](https://github.com/user-attachments/assets/30153afa-8516-4f5b-a2bc-4be44a45297d)


## 関連ページ

[Notion リンク](URLを貼り付けてください)に詳細なドキュメントやタスク内容を記載しています。
